### PR TITLE
fix: add fix for upstream security bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: rickstaa/action-get-semver@v1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Apply hotfix for 'fatal: unsafe repository' error (see #14)
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
 if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
@@ -8,7 +11,7 @@ fi
 input_bump_level="$(echo ${INPUT_BUMP_LEVEL:-patch} | tr '[:upper:]' '[:lower:]')" # Make lowercase
 case $input_bump_level in
   "major" | "minor" | "patch") ;;
-  
+
   *)
     printf '%s\n' "[action-get-semver] Please specify a valid bump level \`${input_bump_level}\` is not valid [major, minor, patch]."
     exit 1
@@ -24,7 +27,7 @@ if [[ -z "${CURRENT_VERSION}" ]]; then
   if [[ "${INPUT_FRAIL}" = 'true' ]]; then
     exit 1
   fi
-  
+
   # Create current and next tag
   CURRENT_VERSION="v0.0.0"
   case "${input_bump_level}" in


### PR DESCRIPTION
This PR fixes an upstream bug that was introduced in https://github.blog/2022-04-12-git-security-vulnerability-announced/. It
can be removed if a patch has been applied to the action ecosystem (See [actions/checkout#766](https://github.com/actions/checkout/issues/766)).

- 🧪 ✅ https://github.com/rickstaa/action-test-repo/runs/6173190620?check_suite_focus=true
